### PR TITLE
Update sensor.py - remove SensorStateClass.MEASUREMENT

### DIFF
--- a/custom_components/my_luminus_pricing/sensor.py
+++ b/custom_components/my_luminus_pricing/sensor.py
@@ -69,7 +69,7 @@ class LuminusBaseSensor(LuminusBaseEntity, SensorEntity):
 
 class YearlyPriceSensor(LuminusBaseSensor):
 
-    _attr_state_class  = SensorStateClass.MEASUREMENT
+    #_attr_state_class  = SensorStateClass.MEASUREMENT -> not needed when you define _attr_device_class as SensorDeviceClass.MONETARY
     _attr_device_class = SensorDeviceClass.MONETARY
     _attr_native_unit_of_measurement = 'EUR/year'
     _attr_suggested_display_precision = 2
@@ -77,7 +77,7 @@ class YearlyPriceSensor(LuminusBaseSensor):
 
 class EnergyPriceSensor(LuminusBaseSensor):
 
-    _attr_state_class  = SensorStateClass.MEASUREMENT
+    #_attr_state_class  = SensorStateClass.MEASUREMENT -> not needed when you define _attr_device_class as SensorDeviceClass.MONETARY
     _attr_device_class = SensorDeviceClass.MONETARY
     _attr_native_unit_of_measurement = 'EUR/kWh'
     _attr_suggested_display_precision = 4


### PR DESCRIPTION
_attr_state_class  = SensorStateClass.MEASUREMENT -> not needed when you define _attr_device_class as SensorDeviceClass.MONETARY

And please create a new release (ex. 1.01)